### PR TITLE
Add getTranslations support with locale filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ $post->title_nl
 $post->getTranslation('title', 'nl')
 ```
 
+To retrieve all translations, you may use `getTranslations`:
+```php
+$post->getTranslations('title');
+// returns ['en' => 'Your first translation', 'nl' => 'Jouw eerste vertaling']
+```
+
+If you omit the key, translations for all translatable attributes will be returned:
+```php
+$post->getTranslations();
+// returns ['title' => ['en' => '...', 'nl' => '...']]
+```
+
+You may also limit the returned locales:
+```php
+$post->getTranslations('title', ['en']);
+// returns ['en' => 'Your first translation']
+```
+
 To check if a translation exists, you may use the `hasTranslation` method:
 ```php
 $post->title_en = 'Your first translation';

--- a/src/UnderscoreTranslatable.php
+++ b/src/UnderscoreTranslatable.php
@@ -42,6 +42,38 @@ trait UnderscoreTranslatable
         return $this->getTranslation($key, $locale, false);
     }
 
+    public function getTranslations(?string $key = null, ?array $allowedLocales = null): array
+    {
+        if ($key === null) {
+            $translations = [];
+
+            foreach ($this->getTranslatableAttributes() as $translatableAttribute) {
+                $translations[$translatableAttribute] = $this->getTranslations($translatableAttribute, $allowedLocales);
+            }
+
+            return $translations;
+        }
+
+        $translations = [];
+        $prefix = $key . '_';
+
+        foreach ($this->attributes as $attribute => $value) {
+            if (! str_starts_with($attribute, $prefix)) {
+                continue;
+            }
+
+            $locale = substr($attribute, strlen($prefix));
+
+            if ($allowedLocales !== null && ! in_array($locale, $allowedLocales)) {
+                continue;
+            }
+
+            $translations[$locale] = $this->getTranslationWithoutFallback($key, $locale);
+        }
+
+        return $translations;
+    }
+
     public function hasTranslation(string $key, ?string $locale = null): bool
     {
         return ! empty($this->getTranslationWithoutFallback($key, $locale));

--- a/tests/UnderscoreTranslatableTest.php
+++ b/tests/UnderscoreTranslatableTest.php
@@ -157,6 +157,56 @@ final class UnderscoreTranslatableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_get_all_translations_for_a_key(): void
+    {
+        $post = new Post();
+        $post->title_en = 'Test en';
+        $post->title_nl = 'Test nl';
+
+        $this->assertEquals([
+            'en' => 'Test en',
+            'nl' => 'Test nl',
+        ], $post->getTranslations('title'));
+    }
+
+    #[Test]
+    public function it_can_get_allowed_translations_for_a_key(): void
+    {
+        $post = new Post();
+        $post->title_en = 'Test en';
+        $post->title_nl = 'Test nl';
+        $post->title_fr = 'Test fr';
+
+        $this->assertEquals([
+            'en' => 'Test en',
+            'fr' => 'Test fr',
+        ], $post->getTranslations('title', ['en', 'fr']));
+    }
+
+    #[Test]
+    public function it_can_get_all_translations_for_all_translatable_attributes(): void
+    {
+        $post = new Post();
+        $post->title_en = 'Test en';
+        $post->title_nl = 'Test nl';
+        $post->field_with_accessor_en = 'Test Accessor';
+        $post->field_with_mutator_nl = 'TEST MUTATOR';
+
+        $this->assertEquals([
+            'title' => [
+                'en' => 'Test en',
+                'nl' => 'Test nl',
+            ],
+            'field_with_accessor' => [
+                'en' => 'test accessor',
+            ],
+            'field_with_mutator' => [
+                'nl' => 'TEST MUTATOR',
+            ],
+        ], $post->getTranslations());
+    }
+
+    #[Test]
     public function it_can_set_a_translatable_attribute_using_a_method(): void
     {
         $post = new Post();


### PR DESCRIPTION
## Summary
- add  to the translatable trait
- support returning translations for a specific key or all translatable attributes
- support optional locale filtering through 
- add PHPUnit coverage for new behavior
- document  usage in README

## Testing
- composer test