### PR TITLE
Add getTranslatedLocales with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ $post->hasTranslation('title', 'nl'); // returns false
 $post->hasTranslation('title', 'fr'); // returns false
 ```
 
+To retrieve only the locales that have a translated column present for a specific key, use `getTranslatedLocales`:
+```php
+$post->title_en = 'Your first translation';
+$post->title_nl = 'Jouw eerste vertaling';
+
+$post->getTranslatedLocales('title'); // returns ['en', 'nl']
+```
+
 In case you do not supply a locale, the current locale will be used.
 
 ### Using a fallback

--- a/src/UnderscoreTranslatable.php
+++ b/src/UnderscoreTranslatable.php
@@ -79,6 +79,11 @@ trait UnderscoreTranslatable
         return ! empty($this->getTranslationWithoutFallback($key, $locale));
     }
 
+    public function getTranslatedLocales(string $key): array
+    {
+        return array_keys($this->getTranslations($key));
+    }
+
     public function setTranslation(string $key, string $locale, mixed $value): self
     {
         if ($this->hasSetMutator($key)) {

--- a/tests/UnderscoreTranslatableTest.php
+++ b/tests/UnderscoreTranslatableTest.php
@@ -157,6 +157,24 @@ final class UnderscoreTranslatableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_get_translated_locales_for_a_key(): void
+    {
+        $post = new Post();
+        $post->title_en = 'Test en';
+        $post->title_nl = 'Test nl';
+
+        $this->assertEquals(['en', 'nl'], $post->getTranslatedLocales('title'));
+    }
+
+    #[Test]
+    public function it_returns_an_empty_array_when_no_translated_locales_exist_for_a_key(): void
+    {
+        $post = new Post();
+
+        $this->assertEquals([], $post->getTranslatedLocales('title'));
+    }
+
+    #[Test]
     public function it_can_get_all_translations_for_a_key(): void
     {
         $post = new Post();


### PR DESCRIPTION
## Summary
- add `getTranslatedLocales(string $key): array` to `UnderscoreTranslatable`
- add tests for populated and empty locale lists
- document `getTranslatedLocales` usage in the README

## Testing
- `composer test`