### PR TITLE
Add model-level translation locale support

### DIFF
--- a/src/UnderscoreTranslatable.php
+++ b/src/UnderscoreTranslatable.php
@@ -2,11 +2,24 @@
 
 namespace Esign\UnderscoreTranslatable;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 
 trait UnderscoreTranslatable
 {
+    protected ?string $translationLocale = null;
+
+    public function setLocale(string $locale): self
+    {
+        $this->translationLocale = $locale;
+
+        return $this;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->translationLocale ?: config('app.locale');
+    }
+
     public function isTranslatableAttribute(string $key): bool
     {
         return in_array($key, $this->getTranslatableAttributes());
@@ -14,7 +27,7 @@ trait UnderscoreTranslatable
 
     public function getTranslatableAttributeName(string $key, ?string $locale = null): string
     {
-        return $key . '_' . ($locale ?? App::getLocale());
+        return $key . '_' . ($locale ?? $this->getLocale());
     }
 
     public function getTranslation(string $key, ?string $locale = null, bool $useFallbackLocale = false): mixed
@@ -113,7 +126,7 @@ trait UnderscoreTranslatable
         }
 
         if ($this->isTranslatableAttribute($key)) {
-            return $this->setTranslation($key, App::getLocale(), $value);
+            return $this->setTranslation($key, $this->getLocale(), $value);
         }
 
         return parent::setAttribute($key, $value);

--- a/tests/UnderscoreTranslatableTest.php
+++ b/tests/UnderscoreTranslatableTest.php
@@ -10,6 +10,18 @@ use Illuminate\Support\Facades\App;
 final class UnderscoreTranslatableTest extends TestCase
 {
     #[Test]
+    public function it_can_set_and_get_the_translation_locale(): void
+    {
+        config(['app.locale' => 'en']);
+
+        $post = new Post();
+
+        $this->assertEquals('en', $post->getLocale());
+        $this->assertSame($post, $post->setLocale('nl'));
+        $this->assertEquals('nl', $post->getLocale());
+    }
+
+    #[Test]
     public function it_can_check_if_an_attribute_is_translatable(): void
     {
         $post = new Post();
@@ -239,9 +251,24 @@ final class UnderscoreTranslatableTest extends TestCase
     public function it_can_set_a_translatable_attribute_using_a_property(): void
     {
         $post = new Post();
+        $post->setLocale('nl');
         $post->title = 'Test en';
 
-        $this->assertEquals('Test en', $post->title_en);
+        $this->assertEquals('Test en', $post->title_nl);
+    }
+
+    #[Test]
+    public function it_can_get_a_translation_using_a_property_with_a_custom_model_locale(): void
+    {
+        $post = new Post();
+        $post->title_en = 'Test en';
+        $post->title_nl = 'Test nl';
+
+        $post->setLocale('nl');
+        $this->assertEquals('Test nl', $post->title);
+
+        $post->setLocale('en');
+        $this->assertEquals('Test en', $post->title);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- add model-level locale state via translationLocale
- add setLocale(string $locale): self and getLocale(): string
- use getLocale() when resolving implicit translation locale in get/set paths
- add tests for locale setter/getter and model-level locale overrides on property access

## Validation
- composer test