### PR TITLE
Allow null in setLocale to reset to app locale

### DIFF
--- a/src/UnderscoreTranslatable.php
+++ b/src/UnderscoreTranslatable.php
@@ -8,7 +8,7 @@ trait UnderscoreTranslatable
 {
     protected ?string $translationLocale = null;
 
-    public function setLocale(string $locale): self
+    public function setLocale(?string $locale): self
     {
         $this->translationLocale = $locale;
 

--- a/tests/UnderscoreTranslatableTest.php
+++ b/tests/UnderscoreTranslatableTest.php
@@ -22,6 +22,19 @@ final class UnderscoreTranslatableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_reset_the_translation_locale_by_passing_null(): void
+    {
+        config(['app.locale' => 'en']);
+
+        $post = new Post();
+        $post->setLocale('nl');
+        $this->assertEquals('nl', $post->getLocale());
+
+        $post->setLocale(null);
+        $this->assertEquals('en', $post->getLocale());
+    }
+
+    #[Test]
     public function it_can_check_if_an_attribute_is_translatable(): void
     {
         $post = new Post();


### PR DESCRIPTION
## Changes

- Updated `setLocale` to accept `?string` instead of `string`, allowing `null` to be passed
- Passing `null` resets `translationLocale` to `null`, causing `getLocale()` to fall back to `config('app.locale')`
- Added a test covering this behaviour